### PR TITLE
Fix position of the imageView to always start at the 0,0 origin

### DIFF
--- a/EFImageViewZoom.swift
+++ b/EFImageViewZoom.swift
@@ -121,7 +121,8 @@ public class EFImageViewZoom: UIScrollView {
     }
     
     public override func awakeFromNib() {
-        self.imageView = UIImageView(frame: self.frame)
+		self.imageView = UIImageView(frame: self.bounds)
+		self.imageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.imageView.contentMode = contentModeImageView
         self.contentMode = contentModeImageView
         self.imageView.clipsToBounds = true


### PR DESCRIPTION
Using frame for inner ImageView is wrong.
If the zoomable ScrollView is not full screen, then its origin would not be 0,0 thus further pushing inner ImageView to the right and bottom.

Using bounds fixes this.